### PR TITLE
Command line flag to make font size user configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ frontend:
 	cd frontend && npm ci
 	cd frontend && npm run build
 
-
 .PHONY: build
 build: frontend
 	go build
@@ -13,3 +12,10 @@ build: frontend
 .PHONY: install
 install: frontend
 	go install
+
+.PHONY: clean
+clean:
+	rm -rf frontend/node_modules
+	rm -rf frontend/dist
+	go clean
+

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 
 <head>
   <link rel="stylesheet" href="./node_modules/xterm/css/xterm.css" />
@@ -13,7 +13,7 @@
 </head>
 
 <body>
-  <div id="terminal" data-theme-light="{{ .ThemeLight }}" data-theme-dark="{{ .ThemeDark }}"></div>
+  <div id="terminal" data-theme-light="{{ .ThemeLight }}" data-theme-dark="{{ .ThemeDark }}" data-font-size="{{ .FontSize }}"></div>
 </body>
 
 </html>

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,6 +1,7 @@
 export type Config = {
   theme?: string;
   themeDark?: string;
+  fontSize?: number;
   xterm: Record<string, unknown>;
   env: Record<string, string>;
 };

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -114,7 +114,6 @@ async function main() {
     }
   }
 
-
   const resp = await fetch(execUrl, {
     method: "POST",
   });

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -15,13 +15,14 @@ async function main() {
   const themeDark = JSON.parse(
     targetElem.getAttribute("data-theme-dark") || "{}",
   );
+  const fontSize = parseInt(targetElem.getAttribute("data-font-size") || "13", 10);
 
   const terminal = new Terminal({
     cursorBlink: true,
     allowProposedApi: true,
     macOptionIsMeta: true,
     macOptionClickForcesSelection: true,
-    fontSize: 13,
+    fontSize: fontSize,
     fontFamily: "Consolas,Liberation Mono,Menlo,Courier,monospace",
     theme: globalThis.matchMedia("(prefers-color-scheme: dark)").matches
       ? themeDark

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ func main() {
 		key       string
 		theme     string
 		themeDark string
+		fontSize  int
 	}
 
 	cmd := cobra.Command{
@@ -62,6 +63,7 @@ func main() {
 				Entrypoint: args[0],
 				ThemeLight: themeLight,
 				ThemeDark:  themeDark,
+				FontSize:   flags.fontSize,
 			})
 			if err != nil {
 				return err
@@ -85,6 +87,7 @@ func main() {
 	cmd.Flags().StringVarP(&flags.key, "key", "k", "", "tls key file")
 	cmd.Flags().StringVar(&flags.theme, "theme", "Tomorrow Night", "default theme to use")
 	cmd.Flags().StringVar(&flags.themeDark, "theme-dark", "", "default dark theme to use, if not set, it will use the same as theme")
+	cmd.Flags().IntVarP(&flags.fontSize, "font-size", "f", 13, "font size to use")
 
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)
@@ -95,6 +98,7 @@ type HandlerParams struct {
 	Entrypoint string
 	ThemeLight string
 	ThemeDark  string
+	FontSize   int
 }
 
 func NewHandler(params HandlerParams) (http.Handler, error) {
@@ -260,6 +264,7 @@ func NewHandler(params HandlerParams) (http.Handler, error) {
 		index.Execute(w, map[string]interface{}{
 			"ThemeLight": string(themeBytes),
 			"ThemeDark":  string(themeDarkBytes),
+			"FontSize":   params.FontSize,
 		})
 	})
 


### PR DESCRIPTION
This pull request adds an optional command line flag, `--font-size`, that makes the font-size user configurable.

Includes a default initial value based on the current default as defined in the CSS, so, for many users this shouldn't impact usage at all. 